### PR TITLE
레이아웃 패딩 적용 및 구분선 컴포넌트 추가

### DIFF
--- a/src/components/Bar/Bar.styles.tsx
+++ b/src/components/Bar/Bar.styles.tsx
@@ -1,0 +1,11 @@
+import { css } from "@emotion/react";
+
+import { COLORS } from "@/styles/color";
+
+export const cssBarStyle = css`
+  position: block;
+  width: calc(100% + 32px);
+  transform: translateX(-16px);
+  border-color: ${COLORS.GRAY1};
+  margin: 0;
+`;

--- a/src/components/Bar/Bar.tsx
+++ b/src/components/Bar/Bar.tsx
@@ -1,0 +1,5 @@
+import { cssBarStyle } from "./Bar.styles";
+
+export const Bar = () => {
+  return <hr css={cssBarStyle} />;
+};

--- a/src/components/Layout/Layout.styles.tsx
+++ b/src/components/Layout/Layout.styles.tsx
@@ -21,6 +21,8 @@ export const cssLayoutContentStyle = ({
 }: {
   fixedFooterHeight?: number;
 }) => css`
+  padding: 16px;
+  padding-top: 60px;
   padding-bottom: ${(fixedFooterHeight || 0) + 16}px;
 `;
 

--- a/src/routes/Home/HomeContainer.tsx
+++ b/src/routes/Home/HomeContainer.tsx
@@ -1,3 +1,11 @@
+import { Bar } from "@/components/Bar/Bar";
+import { cssAlignVerticalStyle } from "@/styles/align";
+
 export const HomeContainer = () => {
-  return <div>홈</div>;
+  return (
+    <div css={cssAlignVerticalStyle({ gap: 16, alignItems: "flex-start" })}>
+      <div>홈</div>
+      <Bar />
+    </div>
+  );
 };


### PR DESCRIPTION
- 레이아웃 콘텐츠 영역에 패딩을 추가했습니다!
- 구분선처럼 콘텐츠 영역 바깥인 화면 너비 전체를 차지하는 컴포넌트에 대해서는 width랑 translate로 처리할까하는데 어떠실까용?