### PR TITLE
배포 오류 해결 - 퍼피티어 실행 경로 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,10 +69,7 @@
     "include": [
       "/"
     ],
-    "puppeteerArgs": [
-      "--no-sandbox",
-      "--disable-setuid-sandbox"
-    ]
+    "puppeteerExecutablePath": "/usr/bin/google-chrome-stable"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
배포 빌드 단계에서 react-snap 이 내부에서 사용하는 puppeteer가 크롬이 없다고 에러를 내더라구용...
ec2에 크롬 설치하고 react-snap 설정에다가 설치된 크롬의 경로 추가해서 해결했습니다!