### PR TITLE
vh 단위 모바일 브라우저에 알맞게 수정

### DIFF
--- a/src/components/Layout/Layout.styles.tsx
+++ b/src/components/Layout/Layout.styles.tsx
@@ -14,7 +14,7 @@ export const cssLayoutStyle = css`
   justify-content: space-between;
   overflow-x: hidden;
   word-break: break-all;
-  min-height: 100vh;
+  min-height: calc(var(--vh, 1vh) * 100);
   margin: 0 auto;
 `;
 
@@ -27,7 +27,7 @@ export const cssLayoutContentStyle = ({
   padding-top: ${(fixedHeight?.header || 0) + 16}px;
   padding-bottom: ${(fixedHeight?.footer || 0) + 16}px;
   min-height: calc(
-    100vh - 32px -
+    var(--vh, 1vh) * 100 - 32px -
       ${fixedHeight?.header ? Math.round(fixedHeight?.header) : 0}px -
       ${fixedHeight?.footer ? Math.round(fixedHeight?.footer) : 0}px
   ); // 헤더와 푸터 높이만큼 뺀 전체 영역을 최소 높이로 가지게 함

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -81,6 +81,7 @@ export const Layout = ({ children }: PropsWithChildren) => {
   };
 
   useEffect(() => {
+    handleResize();
     window.addEventListener("resize", handleResize);
     return () => {
       window.removeEventListener("resize", handleResize);

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -75,6 +75,18 @@ export const Layout = ({ children }: PropsWithChildren) => {
   const [fixedHeaderHeight, setFixedHeaderHeight] = useState<number>();
   const [fixedFooterHeight, setFixedFooterHeight] = useState<number>();
 
+  const handleResize = () => {
+    const vh = window.innerHeight * 0.01;
+    document.documentElement.style.setProperty("--vh", `${vh}px`);
+  };
+
+  useEffect(() => {
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
   useEffect(() => {
     // 자동으로 fixed header, footer의 높이를 계산
     setFixedFooterHeight(

--- a/src/routes/Home/HomeContainer.styles.tsx
+++ b/src/routes/Home/HomeContainer.styles.tsx
@@ -3,6 +3,6 @@ import { css } from "@emotion/react";
 import { cssAlignVerticalStyle } from "@/styles/align";
 
 export const cssHomeContainerStyle = css`
-  height: calc(100vh - 64px - 32px);
+  height: calc(var(--vh, 1vh) * 100 - 64px - 32px);
   ${cssAlignVerticalStyle({ gap: 16, justifyContent: "space-between" })}
 `;


### PR DESCRIPTION
- [https://velog.io/@j8won/모바일-브라우저에서-100vh이-왜-안-돼](https://velog.io/@j8won/%EB%AA%A8%EB%B0%94%EC%9D%BC-%EB%B8%8C%EB%9D%BC%EC%9A%B0%EC%A0%80%EC%97%90%EC%84%9C-100vh%EC%9D%B4-%EC%99%9C-%EC%95%88-%EB%8F%BC) 요거 자바스크립트 이용한 방식으로 했어용
- vh 단위 쓰고 싶으시면 calc(var(--vh, 1vh) * 필요한 길이)) 이렇게 써주시면 됩니당!