### PR TITLE
feat: 회원가입시 닉네임 중복 체크 api 연결 및 validation 추가

### DIFF
--- a/src/api/hooks/auth.ts
+++ b/src/api/hooks/auth.ts
@@ -103,3 +103,17 @@ export const usePostKaKaoSignOut = () => {
     },
   });
 };
+
+export const useGetCheckNickname = () => {
+  return useMutation({
+    mutationFn: (nickName: string): Promise<AxiosResponse<any, any>> => {
+      return api.get(authApiRoute.getCheckNickname(nickName));
+    },
+    onSuccess: (res: AxiosResponse) => {
+      console.log("닉네임 중복 확인을 성공했습니다.", res);
+    },
+    onError: (error) => {
+      console.error("닉네임 중복 확인을 실패했습니다.", error);
+    },
+  });
+};

--- a/src/api/routes/apiRoutes.ts
+++ b/src/api/routes/apiRoutes.ts
@@ -19,4 +19,6 @@ export const authApiRoute = {
   postSignUp: `${API_URL}/signup`, // 회원가입
   postLogOut: `${API_URL}/users/logout`, // 로그아웃
   getMyPage: (userId: string) => `${API_URL}/${userId}/my-page`, // 마이페이지 조회
+  getCheckNickname: (nickName: string) =>
+    `${API_URL}/signup/check-nickname?nickName=${nickName}`, // 닉네임 중복 확인
 };


### PR DESCRIPTION
- 닉네임 중복 체크 api를 연결했습니다.
- 닉네임에 대한 validation을 추가하고 input 하단에 error 메시지 처리를 추가했습니다.